### PR TITLE
Make dashboard server host address configurable

### DIFF
--- a/bot-config.json
+++ b/bot-config.json
@@ -1,6 +1,7 @@
 {
   "scan": {
     "timeframe": "week",
+    "host": "0.0.0.0",
     "port": 8080,
     "balance": 100.0,
     "interval": 300,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ impl Default for AppConfig {
 #[serde(default)]
 pub struct ScanConfig {
     pub timeframe: String,
+    pub host: String,
     pub port: u16,
     pub balance: f64,
     pub interval: u64,
@@ -34,6 +35,7 @@ impl Default for ScanConfig {
     fn default() -> Self {
         Self {
             timeframe: "week".to_string(),
+            host: "127.0.0.1".to_string(),
             port: 8080,
             balance: 100.0,
             interval: 300,

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -206,12 +206,12 @@ async fn evaluations_handler(State(state): State<AppState>) -> impl IntoResponse
     }
 }
 
-/// Start the HTTP server on the given port
-pub async fn start_server(state: AppState, port: u16) -> anyhow::Result<()> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    info!("Dashboard listening on http://127.0.0.1:{port}");
-    info!("  → Main dashboard: http://127.0.0.1:{port}/");
-    info!("  → JSON API:       http://127.0.0.1:{port}/api/data");
+/// Start the HTTP server on the given host and port
+pub async fn start_server(state: AppState, host: &str, port: u16) -> anyhow::Result<()> {
+    let addr: SocketAddr = format!("{host}:{port}").parse()?;
+    info!("Dashboard listening on http://{host}:{port}");
+    info!("  → Main dashboard: http://{host}:{port}/");
+    info!("  → JSON API:       http://{host}:{port}/api/data");
 
     let router = build_router(state);
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ enum Command {
         #[arg(long)]
         timeframe: Option<String>,
 
+        /// Host address to bind the web dashboard (e.g. 0.0.0.0 for all interfaces)
+        #[arg(long)]
+        host: Option<String>,
+
         /// Port for the web dashboard
         #[arg(long)]
         port: Option<u16>,
@@ -171,6 +175,7 @@ async fn main() -> Result<()> {
         Command::Scan {
             dry_run,
             timeframe,
+            host,
             port,
             balance,
             live,
@@ -179,6 +184,7 @@ async fn main() -> Result<()> {
         } => {
             let scan_defaults = app_config.scan;
             let resolved_timeframe = timeframe.unwrap_or(scan_defaults.timeframe);
+            let resolved_host = host.unwrap_or(scan_defaults.host);
             let resolved_port = port.unwrap_or(scan_defaults.port);
             let resolved_balance = balance.unwrap_or(scan_defaults.balance);
             let resolved_interval = interval.unwrap_or(scan_defaults.interval);
@@ -189,6 +195,7 @@ async fn main() -> Result<()> {
                 http,
                 resolved_dry_run,
                 resolved_timeframe,
+                resolved_host,
                 resolved_port,
                 resolved_balance,
                 resolved_live,
@@ -265,6 +272,7 @@ async fn run_scan(
     http: reqwest::Client,
     dry_run: bool,
     timeframe: String,
+    host: String,
     port: u16,
     balance: f64,
     live: bool,
@@ -297,7 +305,7 @@ async fn run_scan(
     // Start dashboard server in background
     let server_state = state.clone();
     tokio::spawn(async move {
-        if let Err(e) = dashboard::start_server(server_state, port).await {
+        if let Err(e) = dashboard::start_server(server_state, &host, port).await {
             error!("Dashboard server error: {e}");
         }
     });


### PR DESCRIPTION
## Summary
This PR makes the HTTP dashboard server's host address configurable, allowing it to bind to any interface instead of being hardcoded to localhost.

## Key Changes
- **dashboard.rs**: Updated `start_server()` function to accept a `host` parameter instead of hardcoding `127.0.0.1`, enabling flexible host binding
- **main.rs**: Added `--host` command-line argument to the `Scan` command for specifying the dashboard host address
- **config.rs**: Added `host` field to `ScanConfig` struct with a default value of `127.0.0.1`
- **bot-config.json**: Updated example configuration to demonstrate binding to all interfaces (`0.0.0.0`)

## Implementation Details
- The host parameter is resolved from CLI arguments with fallback to the configuration file default
- The socket address is now parsed from a formatted string (`{host}:{port}`) instead of using array notation, providing greater flexibility
- Default behavior remains unchanged (localhost binding) unless explicitly configured otherwise
- Users can now bind to `0.0.0.0` to accept connections from all network interfaces

https://claude.ai/code/session_01SJzq7ihdvuTd5Xv9xAdvXd