### PR TITLE
Make WebSocket token subscriptions dynamic via watch channel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use chrono::Utc;
 use clap::{Parser, Subcommand};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 use tracing::{error, info, warn};
 
 use config::load_config;
@@ -312,14 +312,14 @@ async fn run_scan(
 
     // Optionally start WebSocket price feed
     let (ws_tx, mut ws_rx) = broadcast::channel::<polymarket_ws::PriceUpdate>(256);
+    // Watch channel for dynamically updating the token subscription list
+    let (ws_token_tx, ws_token_rx) = watch::channel::<Vec<String>>(vec![]);
 
     if live {
         info!("Starting Polymarket WebSocket price feed...");
         let tx = ws_tx.clone();
         tokio::spawn(async move {
-            // We subscribe to all markets after the first scan — start with empty list.
-            // In a production system this would be updated dynamically.
-            if let Err(e) = polymarket_ws::start_ws_listener(vec![], tx).await {
+            if let Err(e) = polymarket_ws::start_ws_listener(ws_token_rx, tx).await {
                 error!("WebSocket listener error: {e}");
             }
         });
@@ -396,6 +396,32 @@ async fn run_scan(
         };
 
         info!("Found {} delta-neutral pairs", pairs.len());
+
+        // Update WebSocket subscriptions with discovered token IDs
+        if live {
+            let mut token_ids: Vec<String> = pairs
+                .iter()
+                .flat_map(|p| {
+                    let mut ids = vec![
+                        p.low_market.yes_token_id.clone(),
+                        p.high_market.yes_token_id.clone(),
+                    ];
+                    if let Some(ref no_id) = p.low_market.no_token_id {
+                        ids.push(no_id.clone());
+                    }
+                    if let Some(ref no_id) = p.high_market.no_token_id {
+                        ids.push(no_id.clone());
+                    }
+                    ids
+                })
+                .collect();
+            token_ids.sort();
+            token_ids.dedup();
+            if !token_ids.is_empty() {
+                info!("Updating WebSocket subscriptions with {} tokens", token_ids.len());
+                let _ = ws_token_tx.send(token_ids);
+            }
+        }
 
         // Collect recent prices for AI advisor context
         let recent_prices: Vec<f64> = database

--- a/src/polymarket_ws.rs
+++ b/src/polymarket_ws.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, error, info, warn};
 use url::Url;
@@ -38,18 +38,34 @@ struct RawTick {
     side: Option<String>,
 }
 
-/// Start a WebSocket listener that subscribes to the given market token IDs
-/// and broadcasts price updates to the returned receiver channel.
+/// Start a WebSocket listener that dynamically subscribes to market token IDs
+/// received via a `watch` channel and broadcasts price updates.
 ///
 /// The task runs indefinitely in the background; cancel it by dropping the
 /// `broadcast::Sender` handle.
+///
+/// When new token IDs arrive on `token_rx`, the listener reconnects and
+/// subscribes to the updated list.
 pub async fn start_ws_listener(
-    token_ids: Vec<String>,
+    mut token_rx: watch::Receiver<Vec<String>>,
     tx: broadcast::Sender<PriceUpdate>,
 ) -> Result<()> {
     let url = Url::parse(WS_URL)?;
 
     loop {
+        let token_ids = token_rx.borrow_and_update().clone();
+
+        if token_ids.is_empty() {
+            info!("No tokens to subscribe to yet. Waiting for scanner results...");
+            // Wait until the scanner sends us token IDs
+            if token_rx.changed().await.is_err() {
+                // Sender dropped — shut down
+                info!("Token watch channel closed. Stopping WebSocket listener.");
+                return Ok(());
+            }
+            continue;
+        }
+
         info!("Connecting to Polymarket WebSocket at {WS_URL}...");
         let ws_stream = match connect_async(url.as_str()).await {
             Ok((ws, _)) => ws,
@@ -74,30 +90,44 @@ pub async fn start_ws_listener(
             continue;
         }
 
-        // Process incoming messages
-        while let Some(msg) = reader.next().await {
-            match msg {
-                Ok(Message::Text(text)) => {
-                    debug!("WS msg: {text}");
-                    process_ws_message(&text, &tx);
+        // Process incoming messages until an error occurs or tokens are updated
+        loop {
+            tokio::select! {
+                msg = reader.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            debug!("WS msg: {text}");
+                            process_ws_message(&text, &tx);
+                        }
+                        Some(Ok(Message::Ping(data))) => {
+                            let _ = writer.send(Message::Pong(data)).await;
+                        }
+                        Some(Ok(Message::Close(_))) => {
+                            warn!("WebSocket closed by server. Reconnecting...");
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            error!("WebSocket error: {e}. Reconnecting...");
+                            break;
+                        }
+                        None => {
+                            warn!("WebSocket stream ended. Reconnecting...");
+                            break;
+                        }
+                        _ => {}
+                    }
                 }
-                Ok(Message::Ping(data)) => {
-                    // Respond to pings
-                    let _ = writer.send(Message::Pong(data)).await;
-                }
-                Ok(Message::Close(_)) => {
-                    warn!("WebSocket closed by server. Reconnecting...");
+                result = token_rx.changed() => {
+                    if result.is_err() {
+                        info!("Token watch channel closed. Stopping WebSocket listener.");
+                        return Ok(());
+                    }
+                    info!("Token list updated. Reconnecting to re-subscribe...");
                     break;
                 }
-                Err(e) => {
-                    error!("WebSocket error: {e}. Reconnecting...");
-                    break;
-                }
-                _ => {}
             }
         }
 
-        warn!("WebSocket disconnected. Reconnecting in 3s...");
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     }
 }


### PR DESCRIPTION
## Summary
This PR refactors the WebSocket listener to dynamically update its token subscriptions based on discovered delta-neutral pairs, rather than using a static list. The listener now receives token IDs through a `watch` channel and automatically reconnects when the subscription list changes.

## Key Changes
- **Dynamic subscription management**: Changed `start_ws_listener` to accept a `watch::Receiver<Vec<String>>` instead of a static `Vec<String>`, allowing real-time updates to the subscription list
- **Reconnection on token updates**: Implemented `tokio::select!` to monitor both incoming WebSocket messages and changes to the token subscription list, triggering reconnection when tokens are updated
- **Empty token handling**: Added logic to wait for initial token IDs before attempting to connect, preventing unnecessary connection attempts
- **Graceful shutdown**: Properly handles watch channel closure to cleanly shut down the listener
- **Token discovery integration**: In `run_scan`, after discovering delta-neutral pairs, the scanner now extracts all unique token IDs and sends them to the WebSocket listener via the watch channel

## Implementation Details
- The WebSocket listener now uses `tokio::select!` to multiplex between message processing and token list updates
- When token IDs change, the listener breaks out of the message processing loop, waits 3 seconds, and reconnects with the new subscription list
- Token IDs are deduplicated and sorted before being sent to the listener
- The watch channel is initialized with an empty vector, and the listener waits for the first update before connecting

https://claude.ai/code/session_012PFrBcCtPhuiSSoffxWFfr